### PR TITLE
Fedora 41 artifact download missing in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,12 @@ jobs:
         name: debian-latest
         path: debian-latest
 
+    - name: Download Fedora 41 artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: fedora-41-latest
+        path: fedora-41-latest
+
     - name: Download Fedora 40 artifacts
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
The artifact download for Fedora 41 was missing in the release job. As a result no release assets for Fedora 41 were published.